### PR TITLE
Fix/add docs overview

### DIFF
--- a/docs/ObservabilityStack/SetupObservabilityStack.md
+++ b/docs/ObservabilityStack/SetupObservabilityStack.md
@@ -10,7 +10,7 @@ To set up Prometheus stack and Prometheus Pushgateway on local Kubernetes using 
 1) Add Helm Chart Repositories:
 
 ```bash
-helm repo add prometheus-community https://prometheus-community.github.io/helm-charts 
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo update
 ```
 
@@ -20,7 +20,7 @@ helm repo update
 helm install my-kube-prometheus-stack prometheus-community/kube-prometheus-stack --version 57.0.3 -f "./Values/PrometheusStackValues.yaml"
 ```
 
-This command will install the Prometheus stack on your Kubernetes cluster [using these values](./Values/PrometheusStackValues.yaml).
+This command will install the Prometheus stack on your Kubernetes cluster [using these values](https://github.com/SovereignCloudStack/scs-health-monitor/tree/ba9049292c3da5afcdae52b1cca15759e074e950/docs/ObservabilityStack/Values/PrometheusStackValues.yaml).
 
 3) Install Prometheus Pushgateway:
 
@@ -28,7 +28,7 @@ This command will install the Prometheus stack on your Kubernetes cluster [using
 helm install my-prometheus-pushgateway prometheus-community/prometheus-pushgateway --version 2.8.0 -f "./Values/PrometheusPushGateway.yaml"
 ```
 
-This command will install Prometheus Pushgateway on your Kubernetes cluster [using these values](./Values/PrometheusPushGateway.yaml).
+This command will install Prometheus Pushgateway on your Kubernetes cluster [using these values](https://github.com/SovereignCloudStack/scs-health-monitor/tree/ba9049292c3da5afcdae52b1cca15759e074e950/docs/ObservabilityStack/Values/PrometheusPushGateway.yaml).
 
 4) Set Docker Context:
 
@@ -72,7 +72,7 @@ Remember to replace placeholders such as my-kube-prometheus-stack and my-prometh
 Once you've executed these commands, Prometheus stack and Prometheus Pushgateway should be set up and accessible on your local Kubernetes cluster.
 
 7) Uninstall helm chart
-If you want to reinstall or remove the deployed observability stack, you can use the following commands: 
+If you want to reinstall or remove the deployed observability stack, you can use the following commands:
 
 ```bash
 # List deployed helm charts

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,102 @@
+# SCS Health Monitor
+
+Welcome to the SCS Health Monitor project! This repository is dedicated to setting up scenarios for functionality and load testing on a deployed OpenStack environment. We utilize Gherkin language to write testing scenarios, and Python's Behave library to execute these tests.
+
+## Description
+
+The SCS Health Monitor project aims to ensure the robustness and reliability of OpenStack environments by simulating various scenarios and assessing their performance under different loads. By employing Gherkin language and Behave library, we can define clear, human-readable test cases that cover a wide range of functionalities, from basic system checks to complex stress tests.
+
+## Getting Started
+
+To get started with the SCS Health Monitor project, follow these steps:
+
+1. Clone [the repository](https://github.com/SovereignCloudStack/scs-health-monitor) to your local machine.
+2. Install the required dependencies listed in the `requirements.txt` file.
+3. Review the existing Gherkin scenarios in the `features` directory to understand the testing coverage.
+4. Create a *clouds.yaml* file int the root of the repository to be able to perform API calls to OpenStack.
+5. Create a *env.yaml* file containing configuration needed for performing the tests
+6. Execute the tests using Behave library to validate the functionality and performance of your OpenStack environment.
+
+## Usage
+
+Here are some basic commands to run the tests:
+
+```bash
+behave             # Run all scenarios
+behave features/   # Run scenarios in a specific feature file
+behave -t @tag     # Run scenarios with a specific tag
+
+# EXAMPLES
+
+# Runs openstack_create_network.feature feature
+behave ./features/openstack_create_network.feature
+
+#runs both features
+behave
+
+# Runs tests tagged with "network" tag
+behave --tags=network
+```
+
+There is a possibility to run it on the [behavex](https://github.com/hrcorval/behavex) framework as well. To get more information, [here](https://pypi.org/project/behavex/) is a link to the documentation.
+Here are some basic commands to run the tests:
+
+```bash
+behavex                            # Run all scenarios parallel - not recomended 
+behavex --parallel-scheme feature  # Run all of the scenarios, but parallel only the features
+behavex features/                  # Run scenarios in a specific feature file
+behavex -t @tag                    # Run scenarios with a specific tag
+
+# EXAMPLES
+
+# Runs openstack_create_network.feature feature
+behavex ./features/openstack_create_network.feature
+
+# Runs tests tagged with "cleanup" tag
+behavex --tags=cleanup
+```
+
+## Setting up Prometheus and Prometheus Push Gateway locally
+For the purposes of gathering information from the test cases being performed against OpenStack, Prometheus metrics are being gathered during excecution of the test, then later these metrics are pushed to a Prometheus Push Gateway.
+
+[Here](./docs/ObservabilityStack/SetupObservabilityStack.md) you can find a useful quickstart quide on setting up Promethus Stack and Prometheus push gateway locally.
+
+## Exporting metrics to Prometheus Push Gateway
+To be able to push the metrics gathered during test executions, you must first configure the prometheus push gateway endpoint. You achieve this by adding these lines to a *env.yaml*:
+
+``` bash
+# Required 
+# If not present the metrics won't 
+# be pushed by the test scenarios
+PROMETHEUS_ENDPOINT: "localhost:30001"
+
+# Optional (default: "SCS-Health-Monitor") 
+# Specify the job label value that 
+# gets added to the metrics
+PROMETHEUS_BATCH_NAME: "SCS-Health-Monitor"
+
+# Required 
+# The name of the cloud from clouds.yaml
+# that the test scenarios will be ran on
+CLOUD_NAME: "gx"
+
+# Optional (default: true)
+# Apply start time and stop time to prometheus batch name
+APPEND_TIMESTAMP_TO_BATCH_NAME: true
+```
+
+This *env.yaml* file must be placed in the root of the repository. This is where you should be also issuing all the *behave <...>* commands to execute the test scenarios.
+
+## Collaborators
+- Piotr Bigos [@piobig2871](https://github.com/piobig2871)
+- Erik Kostelanský [@Erik-Kostelansky-dNation](https://github.com/Erik-Kostelansky-dNation)
+- Katharina Trentau [@fraugabel](https://github.com/fraugabel)
+- Ľubomír Dobrovodský [@dobrovodskydnation](https://github.com/dobrovodskydnation)
+- Tomáš Smädo [@tsmado](https://github.com/tsmado)
+
+## Useful links
+
+### [Openstack python SDK documentation](https://docs.openstack.org/openstacksdk/latest/user/)
+### [Openstack CLI tool documentation](https://docs.openstack.org/python-openstackclient/latest/)
+### [Parameterisation of tests using scenario outlines](https://jenisys.github.io/behave.example/tutorials/tutorial04.html)
+### [Short but concise tutorial on how to setup behave test scenarios](https://behave.readthedocs.io/en/stable/tutorial.html)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -42,7 +42,7 @@ There is a possibility to run it on the [behavex](https://github.com/hrcorval/be
 Here are some basic commands to run the tests:
 
 ```bash
-behavex                            # Run all scenarios parallel - not recomended 
+behavex                            # Run all scenarios parallel - not recomended
 behavex --parallel-scheme feature  # Run all of the scenarios, but parallel only the features
 behavex features/                  # Run scenarios in a specific feature file
 behavex -t @tag                    # Run scenarios with a specific tag
@@ -59,23 +59,23 @@ behavex --tags=cleanup
 ## Setting up Prometheus and Prometheus Push Gateway locally
 For the purposes of gathering information from the test cases being performed against OpenStack, Prometheus metrics are being gathered during excecution of the test, then later these metrics are pushed to a Prometheus Push Gateway.
 
-[Here](./docs/ObservabilityStack/SetupObservabilityStack.md) you can find a useful quickstart quide on setting up Promethus Stack and Prometheus push gateway locally.
+[Here](https://github.com/SovereignCloudStack/scs-health-monitor/blob/ba9049292c3da5afcdae52b1cca15759e074e950/docs/ObservabilityStack/SetupObservabilityStack.md) you can find a useful quickstart quide on setting up Promethus Stack and Prometheus push gateway locally.
 
 ## Exporting metrics to Prometheus Push Gateway
 To be able to push the metrics gathered during test executions, you must first configure the prometheus push gateway endpoint. You achieve this by adding these lines to a *env.yaml*:
 
 ``` bash
-# Required 
-# If not present the metrics won't 
+# Required
+# If not present the metrics won't
 # be pushed by the test scenarios
 PROMETHEUS_ENDPOINT: "localhost:30001"
 
-# Optional (default: "SCS-Health-Monitor") 
-# Specify the job label value that 
+# Optional (default: "SCS-Health-Monitor")
+# Specify the job label value that
 # gets added to the metrics
 PROMETHEUS_BATCH_NAME: "SCS-Health-Monitor"
 
-# Required 
+# Required
 # The name of the cloud from clouds.yaml
 # that the test scenarios will be ran on
 CLOUD_NAME: "gx"
@@ -85,7 +85,7 @@ CLOUD_NAME: "gx"
 APPEND_TIMESTAMP_TO_BATCH_NAME: true
 ```
 
-This *env.yaml* file must be placed in the root of the repository. This is where you should be also issuing all the *behave <...>* commands to execute the test scenarios.
+This `env.yaml` file must be placed in the root of the repository. This is where you should be also issuing all the `behave` commands to execute the test scenarios.
 
 ## Collaborators
 - Piotr Bigos [@piobig2871](https://github.com/piobig2871)


### PR DESCRIPTION
The [build action for docs.scs.community](https://github.com/SovereignCloudStack/docs/actions/runs/10473182872/job/29004472084?pr=223) fails because of the usage of `<>` without code quotes (see https://github.com/micromark/micromark-extension-mdx-jsx#unexpected-character-at-expected-expect). 

This PR also uses absolute paths for some links, because they also cause issues (tested locally with the docs workflow).
