### PR TITLE
Use alpine instead of busybox for dummy containers; add watch

### DIFF
--- a/container_level_testing/features/steps/container_tools.py
+++ b/container_level_testing/features/steps/container_tools.py
@@ -22,8 +22,8 @@ def create_container(container_name):
         spec=client.V1PodSpec(
             containers=[client.V1Container(
                 name=container_name,
-                image="busybox",
-                command=["sleep", "0"],
+                image="docker.io/library/alpine:3.20.2",
+                command=["sh", "-c", "apk add --no-cache tini-static && /sbin/tini-static -p SIGKILL -g -v sleep infinity"],
                 ports=[client.V1ContainerPort(container_port=80)]
             )]
         )
@@ -45,7 +45,6 @@ def create_service(service_name, port):
 
 
 def get_node_port(client, service_name, namespace):
-
     try:
         # Get the service details
         service = client.read_namespaced_service(name=service_name, namespace=namespace)


### PR DESCRIPTION
This allows dummy containers to use a proper "init" process, tini. It handles SIGINT and SIGTERM, which busybox does not. So sending SIGTERM via "kubectl delete" or via the Python client exits the dummy pod immediately, not waiting for timeout or graceperiod as before.

Also adds watches for container creation and deletion, so sleep can be removed.